### PR TITLE
Minor patches to parse-crontab

### DIFF
--- a/crontab/_crontab.py
+++ b/crontab/_crontab.py
@@ -195,15 +195,18 @@ class _Matcher(object):
                 end = _end
                 if increment is None:
                     return set([start])
-            _assert(_start <= start <= _end,
-                "range start value %r out of range [%r, %r]", start, _start, _end)
-            _assert(_start <= end <= _end,
-                "range end value %r out of range [%r, %r]", end, _start, _end)
+            _assert(_start <= start <= _end_limit,
+                "range start value %r out of range [%r, %r]",
+                start, _start, _end_limit)
+            _assert(_start <= end <= _end_limit,
+                "range end value %r out of range [%r, %r]",
+                end, _start, _end_limit)
             _assert(start <= end,
                 "range start value %r > end value %r", start, end)
             return set(range(start, end+1, increment or 1))
 
         _start, _end = _ranges[which]
+        _end_limit = _end
         # wildcards
         if entry in ('*', '?'):
             if entry == '?':
@@ -232,10 +235,19 @@ class _Matcher(object):
                 "you can only use positive increment values, you provided %r",
                 increment)
 
+        # allow Sunday to be specified as weekday 7
+        if which == 4:
+            _end_limit = 7
+
         # handle all of the a,b,c and x-y,a,b entries
         good = set()
         for it in entry.split(','):
             good.update(_parse_piece(it))
+
+        # change Sunday to weekday 0
+        if which == 4 and 7 in good:
+            good.discard(7)
+            good.add(0)
 
         return good, _end
 


### PR DESCRIPTION
I made some changes to parse-crontab to allow it to also run on Python 3.

Then when testing an application I'm working on, I had trouble with the schedule entry `* * * * 7`.  Parse-crontab accepted it (as the 7 is not part of a range) but it didn't match Sundays.  My change is supposed to convert 7 when specified for a weekday to 0.
