### PR TITLE
Fix skipping matches with a more brute-force search

### DIFF
--- a/crontab/_crontab.py
+++ b/crontab/_crontab.py
@@ -315,38 +315,8 @@ class CronTab(object):
             now = datetime.datetime.fromtimestamp(now)
         # get a reasonable future/past start time
         future = now.replace(second=0, microsecond=0) + increments[0]()
-        if future < now:
-            # we are going backwards...
-            _test = lambda: future.year < self.matchers.year
-        else:
-            # we are going forwards
-            _test = lambda: self.matchers.year < future.year
-        to_test = 0
-        while to_test < 6:
-            incr = increments[to_test]
-            ch = False
-            inc = None
-            while not self._test_match(to_test, future):
-                inc = incr(future, self.matchers)
-                future += inc
-                ch = True
-                if _test():
-                    return None
-            if ch:
-                for i in xrange(0, to_test-1):
-                    future = increments[6+i](future, inc)
-                to_test = 0
-                continue
-
-            to_test += 1
-
-        # verify the match
-        match = [self._test_match(i, future) for i in xrange(6)]
-        _assert(all(match),
-            "\nYou have discovered a bug with crontab, please notify the\n" \
-            "author with the following information:\n" \
-            "crontab: %r\n" \
-            "now: %r", ' '.join(m.input for m in self.matchers), now)
+        while not all([self._test_match(i, future) for i in xrange(6)]):
+            future += increments[0]()
         delay = future - now
         if not delta:
             delay = future - datetime.datetime(1970, 1, 1)


### PR DESCRIPTION
The problem: The current algorithm for next() can return a too-far answer. Example: '10, 20 15 \* \* *' will point to 15:20 if run at 14:15, but will give the correct answer (15:10) if run at 15:01. This is true any time a field has a list of values, and the current time's value for that field is greater than any of those values. I've tried (with some friends) to brainstorm a more efficient way to make this work, and there are options like generating a list of all possible matches, and finding the lowest one that is greater than now, but this might be a good place to honor the K.I.S.S. principle.
