### PR TITLE
BUG: Allow "-sun" to be specified as the RHS of a weekday range

### DIFF
--- a/crontab/_crontab.py
+++ b/crontab/_crontab.py
@@ -207,6 +207,9 @@ class _Matcher(object):
         def _parse_piece(it):
             if '-' in it:
                 start, end = map(_fix, it.split('-'))
+                # Allow "sat-sun"
+                if which == 4 and end == 0:
+                    end = 7
             elif it == '*':
                 start = _start
                 end = _end

--- a/tests/test_crontab.py
+++ b/tests/test_crontab.py
@@ -85,6 +85,9 @@ class TestCrontab(unittest.TestCase):
         self._run_test('0 0 ? 7 mon', 4*86400, datetime.datetime(2011, 7, 15))
         self._run_test('0 0 ? 7 mon', 366*86400, datetime.datetime(2011, 7, 25, 1))
         self._run_test('0 0 ? 8 mon-fri', 5*86400 + 1, datetime.datetime(2011, 7, 27, 1))
+        self._run_test('0 12 * * sat-sun', 129600, datetime.datetime(2015, 11, 6), 129600)
+        self._run_test('0 12 * * sat-sun', 86400, datetime.datetime(2015, 11, 7, 12), 86400)
+        self._run_test('0 12 * * sat-sun', 518400, datetime.datetime(2015, 11, 8, 12), 518400)
 
     def test_last_day(self):
         self._run_test('0 0 L 2 ?', 28*86400, datetime.datetime(2011, 1, 31))


### PR DESCRIPTION
It should be possible to specify Sunday, i.e., "sun", on the
right-hand side of a weekday range. In other words, "sat-sun" should
work.