### PR TITLE
two CronTab with the same crontab command should be equal

### DIFF
--- a/crontab/_crontab.py
+++ b/crontab/_crontab.py
@@ -321,9 +321,18 @@ class _Matcher(object):
 
 
 class CronTab(object):
-    __slots__ = 'matchers',
+    __slots__ = 'matchers', '_crontab_command'
     def __init__(self, crontab):
         self.matchers = self._make_matchers(crontab)
+        self._crontab_command = crontab
+
+    def __str__(self):
+        return '<{}: {}>'.format(self.__class__.__name__, self._crontab_command)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._crontab_command == other._crontab_command
+        return False
 
     def _make_matchers(self, crontab):
         '''

--- a/tests/test_crontab.py
+++ b/tests/test_crontab.py
@@ -31,6 +31,10 @@ class TestCrontab(unittest.TestCase):
         delay = ct.next(now, default_utc=True)
         assert delay is None, (crontab, delay, now, now+datetime.timedelta(seconds=delay))
 
+    def test_equality(self):
+        s = '* * * * *'
+        assert CronTab(s) == CronTab(s)
+
     def test_closest(self):
         ce = CronTab("*/15 10-15 * * 1-5")
         t945 = datetime.datetime(2013, 1, 1, 9, 45) # tuesday


### PR DESCRIPTION
Fantastic library!

I've been using `parse-crontab` in my own project, and I aim to write tests to see if the program had successfully extracted the right crontab command, so I figured it can be handy to have `assert A.crontab == Crontab('* * * * *')` to see if the parsing results were right.