### PR TITLE
Fix setup script to read details from PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     license='GNU LGPL v2.1',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 try:
-    with open('README') as f:
+    with open('README.rst') as f:
         long_description = f.read()
 except:
     long_description = ''


### PR DESCRIPTION
hi, 

I’m user of your library. Thanks! 
And I fixed two points of `setup.py`.

- Add `Python3.6`  classifiers
- Fix to be able to read  `README.rst` from PyPI